### PR TITLE
Update Xively.class.nut

### DIFF
--- a/Xively.class.nut
+++ b/Xively.class.nut
@@ -88,6 +88,6 @@ class Xively.Channel {
     }
 
     function toJson() {
-    	return http.jsonencode({ _id = this._id, current_value = this._value });
+    	return http.jsonencode({ id = this._id, current_value = this._value });
     }
 }


### PR DESCRIPTION
Removed the '_' (row 91, "_id = ...") witch causes an error (400,"Datastream ids must be strings, you supplied: ") while putting data to Xively.
